### PR TITLE
Make sure all hidden files are outside the background image

### DIFF
--- a/support/template.applescript
+++ b/support/template.applescript
@@ -16,6 +16,7 @@ on run (volumeName)
 				set current view to icon view
 				set toolbar visible to false
 				set statusbar visible to false
+				set position of every item to {theBottomRightX + 100, 100}
 				set the bounds to {theXOrigin, theYOrigin, theBottomRightX, theBottomRightY}
 				set statusbar visible to false
 			end tell


### PR DESCRIPTION
If the user enabled Mac OS X to show hidden files then when mounted the
generated DMG package may show some of them within the bounds of the
background image.

![hidden-files](https://cloud.githubusercontent.com/assets/468091/5818990/bcb429da-a0c2-11e4-9cf0-3bd912eb36a3.png)

This change makes sure that all items in the DMG package are moved to a
position outside the bounds of the background image. The
POSITITION_CLAUSE and APPLICATION_CLAUSE that are executed later will
still place the app icon and Application correctly.